### PR TITLE
feat(pool): impl flexible algorithm for bigger allocations than `chunk_size`

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -77,6 +77,7 @@ fn main() {
     let system = system::Alloq::new(unsafe { HEAP_SIM.as_mut_ptr_range() });
 
     println!("running benchmarks");
+    println!("heap range: {:?}", unsafe { HEAP_SIM.as_mut_ptr_range() });
     run_benches!(dir, &first, &best, &bump, &debump, &pool, &statiq, &system, &flex_pool);
     println!("benchmarks results saved on {dir}");
 }

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -70,13 +70,14 @@ fn main() {
     let pool = unsafe {
         pool::Alloq::with_chunk_size(HEAP_SIM.as_mut_ptr_range(), HEAP_SIM_SIZE / 1024, 2)
     };
+    let flex_pool = pool::Alloq::new(unsafe { HEAP_SIM.as_mut_ptr_range() });
     let first = first::Alloq::new(unsafe { HEAP_SIM.as_mut_ptr_range() });
     let best = best::Alloq::new(unsafe { HEAP_SIM.as_mut_ptr_range() });
     let statiq = statiq::Alloq::new(unsafe { HEAP_SIM.as_mut_ptr_range() });
     let system = system::Alloq::new(unsafe { HEAP_SIM.as_mut_ptr_range() });
 
     println!("running benchmarks");
-    run_benches!(dir, &first, &best, &bump, &debump, &pool, &statiq, &system);
+    run_benches!(dir, &first, &best, &bump, &debump, &pool, &statiq, &system, &flex_pool);
     println!("benchmarks results saved on {dir}");
 }
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -683,7 +683,7 @@ pub mod tests {
         let mut heap_stackish = [0; 1024];
         let alloqer = Alloq::new(heap_stackish.as_mut_ptr_range());
         let vec: Vec<_> = (0..5).map(|_| alloqer.alloq(Layout::new::<()>())).collect();
-        for p in vec {
+        for p in vec.iter().rev().cloned() {
             unsafe { alloqer.dealloq(p, Layout::new::<()>()) }
         }
         unsafe {
@@ -705,7 +705,19 @@ pub mod tests {
     fn tiny_chunk_allocation() {
         let mut heap_stackish = [0u8; 1024];
         let alloqer = unsafe { Alloq::with_chunk_size(heap_stackish.as_mut_ptr_range(), 48, 2) };
-        let v: Vec<_> = (0..10).map(|x| Box::new_in(x, &alloqer)).collect();
-        assert!(v.iter().enumerate().all(|(i, x)| **x == i));
+        let v: Vec<_> = (0..10u128).map(|x| Box::new_in(x, &alloqer)).collect();
+        assert!(v.iter().enumerate().all(|(i, x)| **x == i as u128));
+    }
+
+    #[test]
+    fn tiny_chunk_unsorted_allocation() {
+        let mut heap_stackish = [0u8; 1024];
+        let alloqer = unsafe { Alloq::with_chunk_size(heap_stackish.as_mut_ptr_range(), 48, 2) };
+        let vec: Vec<_> = (0..5).map(|_| alloqer.alloq(Layout::new::<()>())).collect();
+        for p in vec.iter().rev().cloned() {
+            unsafe { alloqer.dealloq(p, Layout::new::<()>()) }
+        }
+        let v: Vec<_> = (0..10u128).map(|x| Box::new_in(x, &alloqer)).collect();
+        assert!(v.iter().enumerate().all(|(i, x)| **x == i as u128));
     }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -133,12 +133,13 @@ impl RawChunk {
         RawChunkIter((self as *const RawChunk) as *mut RawChunk)
     }
 
+    #[inline(always)]
+    pub fn back_iter(&self) -> RawChunkBackIter {
+        RawChunkBackIter((self as *const RawChunk) as *mut RawChunk)
+    }
+
     pub fn first(&self) -> *const RawChunk {
-        let mut first = self;
-        while !first.back.is_null() {
-            first = unsafe { &*first.back };
-        }
-        first
+        self.back_iter().last().unwrap()
     }
 
     #[inline(always)]
@@ -229,6 +230,21 @@ impl Iterator for RawChunkIter {
             None
         } else {
             self.0 = unsafe { (*self.0).next };
+            Some(r)
+        }
+    }
+}
+
+pub struct RawChunkBackIter(*mut RawChunk);
+
+impl Iterator for RawChunkBackIter {
+    type Item = *mut RawChunk;
+    fn next(&mut self) -> Option<Self::Item> {
+        let r = self.0;
+        if r.is_null() {
+            None
+        } else {
+            self.0 = unsafe { (*self.0).back };
             Some(r)
         }
     }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -310,6 +310,8 @@ impl Pool {
         let mut last: *mut RawChunk = null_mut();
         for c in (*first).iter() {
             if !start.is_null() && (*last).next == c {
+        let mut aligned: *mut RawChunk = null_mut();
+        // TODO: use `chunk_size` for optimisation reasons
                 last = c;
                 if needed <= chunk_size {
                     (*start).slice_until(&mut *last);
@@ -322,6 +324,7 @@ impl Pool {
                 last = c;
                 let aligned = crate::align_up(start as usize, layout.align());
                 needed = layout.size() - (aligned - (start as usize));
+                aligned = crate::align_up(start as usize, layout.align()) as *mut RawChunk;
             }
         }
         while needed > 0 {


### PR DESCRIPTION
Sorts the free chunks, and tries to find a free block that supports it. Deallocating just take the block and the last chunk from `back` and connect to `free_last`. No new overheads over old `pool` implementation.